### PR TITLE
Re-add visibility: hidden to fix double checkboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@ node_modules
 vendor
 composer.lock
 
+# Local tests folder for less styles
 test
+
+# Compiled LESS file
+resources/less/forum.css

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,5 +1,6 @@
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input {
+  visibility: hidden;
   margin-right: 8px;
   position: relative;
 }

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,62 +1,62 @@
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input {
-  visibility: hidden;
-  margin-right: 8px;
-  position: relative;
+  visibility: hidden !important;
+  margin-right: 8px !important;
+  position: relative !important;
 }
 
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input::before,
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input::after {
-  position: absolute;
+  position: absolute !important;
 }
 
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input::before {
-  content: "";
-  display: inline-block;
-  visibility: visible;
+  content: "" !important;
+  display: inline-block !important;
+  visibility: visible !important;
 
-  height: 16px;
-  width: 16px;
+  height: 16px !important;
+  width: 16px !important;
 
-  border: 2px solid #000;
+  border: 2px solid #000 !important;
 
   /* centres with label text */
-  top: -3px;
+  top: -3px !important;
 
-  cursor: pointer;
+  cursor: pointer !important;
 }
 
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input:disabled::before {
-  background: rgba(128, 128, 128, 0.4);
+  background: rgba(128, 128, 128, 0.4) !important;
 }
 
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input:checked::after {
-  content: "";
-  display: inline-block;
-  visibility: visible;
+  content: "" !important;
+  display: inline-block !important;
+  visibility: visible !important;
 
-  height: 4px;
-  width: 9px;
+  height: 4px !important;
+  width: 9px !important;
 
-  border-left: 2px solid #000;
-  border-bottom: 2px solid #000;
+  border-left: 2px solid #000 !important;
+  border-bottom: 2px solid #000 !important;
 
-  transform: rotate(-45deg);
+  transform: rotate(-45deg) !important;
 
-  left: 5px;
-  bottom: 4px;
+  left: 5px !important;
+  bottom: 4px !important;
 
-  cursor: pointer;
+  cursor: pointer !important;
 }
 
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input:disabled::before,
 label.extendedmarkdown--checkbox
   > input[type="checkbox"].extendedmarkdown--checkbox-input:disabled::after {
-  cursor: not-allowed;
+  cursor: not-allowed !important;
 }


### PR DESCRIPTION
After commit a962002 removed `visibility: hidden` from the input, there is now a checkbox visible under the custom one.

The CSS I made doesn't change the styling of the checkboxes themselves. Instead, it uses `::before` and `::after` pseudo-elements to create a new checkbox which displays a checkmark based on the input's `:checked` CSS attribute.

![Double checkboxes](https://user-images.githubusercontent.com/7406822/64966942-a0be5400-d897-11e9-8f19-ea6449a710ca.png)